### PR TITLE
Fixing possible null value for file extension #7

### DIFF
--- a/EventListener/DcaFilesListener.php
+++ b/EventListener/DcaFilesListener.php
@@ -104,11 +104,18 @@ class DcaFilesListener
         }
 
         // render when valid image type
-        if ( null !== $dc->id )
+        if ( null !== $dc->id && '' !== $dc->id )
         {
-            $fileExtension = \strtolower(pathinfo((string) $dc->id)['extension']);
+            // extract the extension from the file path
+            $fileExtension = pathinfo((string) $dc->id)['extension'];
 
-            if ( in_array($fileExtension, $this->validImageExtensions) )
+            // check if path could get read
+            if ($fileExtension)
+            {
+                $fileExtension = \strtolower($fileExtension);
+            }
+
+            if ( $fileExtension && in_array($fileExtension, $this->validImageExtensions) )
             {
                 $this->addFieldsToPalette($dc->table);
             }


### PR DESCRIPTION
While extracting the file extension and lowering the result there could have been an error
when the extension is null. Therefore, the extracted value now gets checked.

The additional check for `'' !== $dc->id` on line 107 helps to avoid unnecessary function calls.